### PR TITLE
feat: support typed container port mappings fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Created when `service_type = "scheduled_task"`:
 | `name_suffix` | Suffix appended to the service name for multiple services per component | `string` | `""` |
 | `port` | The port the container listens on (not required for `scheduled_task`) | `string` | `"0"` |
 
+If `port` is not `"0"`, the module uses `port`; if `port` is `"0"` and `container_port_mappings` is set, the module uses `container_port_mappings`.
+
 ### Load Balancing
 
 | Name | Description | Type | Default |
@@ -200,7 +202,7 @@ Created when `service_type = "scheduled_task"`:
 | `nofile_soft_ulimit` | Soft ulimit for number of open files | `string` | `"4096"` |
 | `stop_timeout` | Seconds before container is forcefully killed (max 120) | `string` | `"120"` |
 | `container_labels` | Additional Docker labels for the container | `map(string)` | `{}` |
-| `container_port_mappings` | JSON array of port mappings (overrides `port` if set) | `string` | `""` |
+| `container_port_mappings` | Port mappings list used when `port` is `"0"` and mappings are provided | `list(object({containerPort=number, hostPort=optional(number), protocol=optional(string), name=optional(string), appProtocol=optional(string)}))` | `null` |
 | `extra_hosts` | Entries to add to `/etc/hosts` in the container | `list(object({hostname, ipAddress}))` | `[]` |
 
 ### Environment & Secrets

--- a/main.tf
+++ b/main.tf
@@ -48,7 +48,7 @@ module "service_container_definition" {
   platform_secrets    = var.platform_secrets
   custom_secrets      = var.custom_secrets
   platform_config     = var.platform_config
-  port_mappings       = var.port != "0" ? [{ containerPort = var.port }] : []
+  port_mappings       = var.port != "0" ? [{ containerPort = var.port }] : (var.container_port_mappings != null && length(var.container_port_mappings) > 0 ? var.container_port_mappings : [])
   mount_points        = [var.container_mountpoint]
   ulimits = [{
     name      = "nofile"

--- a/variables.tf
+++ b/variables.tf
@@ -131,9 +131,15 @@ variable "container_mountpoint" {
 }
 
 variable "container_port_mappings" {
-  description = "JSON document containing an array of port mappings for the container defintion - if set port is ignored (optional)."
-  default     = ""
-  type        = string
+  type = list(object({
+    containerPort = number
+    hostPort      = optional(number)
+    protocol      = optional(string)
+    name          = optional(string)
+    appProtocol   = optional(string)
+  }))
+  description = "The port mappings to configure for the container. This is a list of maps. Each map should contain \"containerPort\", \"hostPort\", and \"protocol\", where \"protocol\" is one of \"tcp\" or \"udp\". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort"
+  default     = null
 }
 
 variable "container_labels" {


### PR DESCRIPTION
## Summary
- use container_port_mappings when port is "0" and mappings are provided
- keep existing single-port behavior when port is not "0"
- update README documentation for either/or behavior and typed container_port_mappings input

## Changes
- update module port_mappings conditional logic
- align variable type for container_port_mappings with container-definition expectations
- refresh README input docs to match behavior and type

## Testing
- validated main.tf syntax and no errors reported